### PR TITLE
fix: download tgz files correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,8 @@ jobs:
           done
           # cr command.. will fail
           cr index --owner "spaceandtimelabs" --git-repo sxt-node-chart-repo --push || cat .cr-index/index.yaml
+          git checkout -t origin/gh-pages
+          mv .cr-index/index.yaml index.yaml
+          git add index.yaml
+          git commit -m "update index.yaml"
+          git push origin HEAD


### PR DESCRIPTION
There seems to be a bug in GitHub where using the browser url yields a
Not Found error in private repositories.

https://github.com/orgs/community/discussions/84909

After looking at the suggestion in
https://stackoverflow.com/questions/20396329/how-to-download-github-release-from-private-repo-using-command-line
we decided to download them using the GitHub API directly.
