### PR TITLE
feat: Updated sxt-node charts to support configurable RPC options

### DIFF
--- a/charts/sxt-node-chart/templates/sxt-node-statefulset.yaml
+++ b/charts/sxt-node-chart/templates/sxt-node-statefulset.yaml
@@ -148,18 +148,18 @@ spec:
 {{- end }}
 {{- if .Values.sxt.isRpcNode }}
         - --rpc-rate-limit
-        - "250"
+        - "{{ .Values.sxt.rpc.rate }}"
         - --rpc-external
         - --rpc-methods
-        - "safe"
+        - "{{ .Values.sxt.rpc.methods }}"
         - --rpc-port
-        - "{{ .Values.sxt.rpcPort }}"
+        - "{{ .Values.sxt.rpc.port }}"
         - --rpc-max-connections
-        - "10000"
+        - "{{ .Values.sxt.rpc.maxConnections }}"
         - --rpc-max-request-size
-        - "1024"
+        - "{{ .Values.sxt.rpc.maxRequestSize }}"
         - --rpc-max-response-size
-        - "1024"
+        - "{{ .Values.sxt.rpc.maxResponseSize }}"
         - --rpc-cors
         - "all"
 {{- end }}

--- a/charts/sxt-node-chart/values.yaml
+++ b/charts/sxt-node-chart/values.yaml
@@ -29,7 +29,13 @@ sxt:
     tag: "testnet-0.45.1"
   p2pService: true
   port: 30333
-  rpcPort: 9944
+  rpc:
+    port: 9944
+    rate: 250
+    methods: "safe"
+    maxConnections: 10000
+    maxRequestSize: 1024
+    maxResponseSize: 1024
   p2pLbPort: 30333
   genesisPath:
   bootnodes:


### PR DESCRIPTION
RPC options were not previously being pulled from the values file. This PR adds those flags as configurable values, so that we can update them via the GitHub Actions in the 'live' repo with no changes to the underlying charts.