### PR TITLE
chore: remove version flag so it always uses latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ sxt-node helm chart repository
 For installation on Kubernetes we have created a helm chart sxt-node-chart. Adding Helm repository with following command:
 
 ```
-   helm repo add sxt-charts https://spaceandtimelabs.github.io/sxt-node-helm-charts
-   helm repo update sxt-charts
-   helm search repo sxt-charts --versions
+helm repo add sxt-charts https://spaceandtimelabs.github.io/sxt-node-helm-charts
+helm repo update sxt-charts
+helm search repo sxt-charts --versions
 ```
 
 Once the Helm configuration is done (assume to be located at `./values.yaml`, we can now run the following command with proper KUBECONFIG to install the chart:
 
 ```
-   helm upgrade --install sxt-testnet-validator sxt-charts/sxt-node-chart \
-   --version=0.3.4 -n sxt-testnet --create-namespace -f ./values.yaml --dependency-update
+helm upgrade --install sxt-testnet-validator sxt-charts/sxt-node-chart \
+    --version=0.3.4 -n sxt-testnet --create-namespace -f ./values.yaml --dependency-update
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once the Helm configuration is done (assume to be located at `./values.yaml`, we
 
 ```
 helm upgrade --install sxt-testnet-validator sxt-charts/sxt-node-chart \
-    --version=0.3.4 -n sxt-testnet --create-namespace -f ./values.yaml --dependency-update
+    -n sxt-testnet --create-namespace -f ./values.yaml --dependency-update
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For installation on Kubernetes we have created a helm chart sxt-node-chart. Addi
 Once the Helm configuration is done (assume to be located at `./values.yaml`, we can now run the following command with proper KUBECONFIG to install the chart:
 
 ```
-   helm upgrade --install sxt-testnet-validator sxt-charts/sxt-node-chart
+   helm upgrade --install sxt-testnet-validator sxt-charts/sxt-node-chart \
    --version=0.3.4 -n sxt-testnet --create-namespace -f ./values.yaml --dependency-update
 ```
 


### PR DESCRIPTION
This way we don't have to worry about having to update the number when a
new release happens, or accidentally copy-pasting this command and
wondering why it's stuck in an old version.